### PR TITLE
Fix indentation error after except statement

### DIFF
--- a/databricks_sql_profiler_analysis_en.py
+++ b/databricks_sql_profiler_analysis_en.py
@@ -3488,7 +3488,7 @@ def analyze_bottlenecks_with_llm(metrics: Dict[str, Any]) -> str:
                     print(f"📊 Extracted statistics for bottleneck analysis: {len(cost_statistics)} characters")
                         
                 except Exception as e:
-                print(f"⚠️ Failed to load EXPLAIN COST results for bottleneck analysis: {str(e)}")
+                    print(f"⚠️ Failed to load EXPLAIN COST results for bottleneck analysis: {str(e)}")
         
         if not explain_files and not cost_files:
             # フォールバック: 古いファイル名パターンもチェック


### PR DESCRIPTION
Fixes an IndentationError by correctly indenting a print statement within an except block.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5c0ef97-51f9-4c47-89ca-51e2f8f29dfe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e5c0ef97-51f9-4c47-89ca-51e2f8f29dfe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

