### PR TITLE
Change sql file extension to txt

### DIFF
--- a/databricks_sql_profiler_analysis_en.py
+++ b/databricks_sql_profiler_analysis_en.py
@@ -138,8 +138,8 @@ def save_debug_query_trial(query: str, attempt_num: int, trial_type: str, query_
         if not query_id:
             query_id = f"trial_{attempt_num}"
         
-        # Generate filename: debug_trial_{attempt_num}_{trial_type}_{timestamp}.sql
-        filename = f"debug_trial_{attempt_num:02d}_{trial_type}_{timestamp}.sql"
+        # Generate filename: debug_trial_{attempt_num}_{trial_type}_{timestamp}.txt
+        filename = f"debug_trial_{attempt_num:02d}_{trial_type}_{timestamp}.txt"
         
         # Prepare metadata information
         metadata_header = f"""-- 🐛 DEBUG: Optimization trial query (DEBUG_ENABLED=Y)


### PR DESCRIPTION
Change debug trial file extension from `.sql` to `.txt` to prevent SQL engine execution errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f5c0fc1-4cb0-4c29-b8a8-0a0cd3f1fbd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4f5c0fc1-4cb0-4c29-b8a8-0a0cd3f1fbd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

