### PR TITLE
Changes from background agent bc-a617fe60-0dc6-4a53-9925-2f9f9bbde04c

### DIFF
--- a/databricks_sql_profiler_analysis_en.py
+++ b/databricks_sql_profiler_analysis_en.py
@@ -9401,6 +9401,12 @@ def format_trial_history_summary(optimization_attempts: list, language: str = 'j
         cost_ratio = attempt.get('cost_ratio', 1.0)
         memory_ratio = attempt.get('memory_ratio', 1.0)
         
+        # None値のハンドリング
+        if cost_ratio is None:
+            cost_ratio = 1.0
+        if memory_ratio is None:
+            memory_ratio = 1.0
+        
         # ステータス表示
         status_text = status_mapping.get(language, status_mapping['en']).get(status, status)
         
@@ -9794,6 +9800,13 @@ Statistical optimization has been executed (details available with DEBUG_ENABLED
             if performance_comparison:
                 cost_ratio = performance_comparison.get('total_cost_ratio', 1.0)
                 memory_ratio = performance_comparison.get('memory_usage_ratio', 1.0)
+                
+                # None値のハンドリング
+                if cost_ratio is None:
+                    cost_ratio = 1.0
+                if memory_ratio is None:
+                    memory_ratio = 1.0
+                    
                 cost_improvement = f"{(1-cost_ratio)*100:.1f}"
                 memory_improvement = f"{(1-memory_ratio)*100:.1f}"
             
@@ -10043,6 +10056,13 @@ The following topics are analyzed for process evaluation:
             if performance_comparison:
                 cost_ratio = performance_comparison.get('total_cost_ratio', 1.0)
                 memory_ratio = performance_comparison.get('memory_usage_ratio', 1.0)
+                
+                # None値のハンドリング
+                if cost_ratio is None:
+                    cost_ratio = 1.0
+                if memory_ratio is None:
+                    memory_ratio = 1.0
+                    
                 cost_improvement = f"{(1-cost_ratio)*100:.1f}"
                 memory_improvement = f"{(1-memory_ratio)*100:.1f}"
             


### PR DESCRIPTION
Add `None` checks for cost and memory ratios to prevent `TypeError` during report generation.

The `cost_ratio` and `memory_ratio` could be `None` in the optimization attempt details, leading to a `TypeError` when attempting to perform arithmetic operations (e.g., `1 - None`). This change ensures that if these values are `None`, they default to `1.0` to avoid the error.

---
<a href="https://cursor.com/background-agent?bcId=bc-a617fe60-0dc6-4a53-9925-2f9f9bbde04c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a617fe60-0dc6-4a53-9925-2f9f9bbde04c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

